### PR TITLE
Feature/generic field compare

### DIFF
--- a/src/app/core/services/forms.service.ts
+++ b/src/app/core/services/forms.service.ts
@@ -1,18 +1,18 @@
-import {Injectable} from '@angular/core';
-import {AbstractControl, FormGroup} from '@angular/forms';
+import { Injectable } from "@angular/core";
+import { AbstractControl, FormGroup } from "@angular/forms";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: "root"
 })
 export class FormsService {
-
-  constructor() {
-  }
+  constructor() {}
 
   // Common:
 
   checkIfFieldIsRequired(control: AbstractControl): boolean {
-    if (!control.validator) return false;
+    if (!control.validator) {
+      return false;
+    }
     const validator = control.validator({} as AbstractControl);
     return validator && !!validator.required;
   }
@@ -21,13 +21,19 @@ export class FormsService {
     return control.touched && control.invalid;
   }
 
-  checkIfValuesMatching(value1Key: string, value2Key: string) {
+  checkIfValuesMatching(
+    value1Key: string,
+    value2Key: string,
+    type: string = "value"
+  ) {
     return (group: FormGroup) => {
       const value1Input = group.controls[value1Key];
       const value2Input = group.controls[value2Key];
-      return (value1Input.value !== value2Input.value)
-        ? value2Input.setErrors({ notEquivalent: true })
-        : value2Input.setErrors(null);
+      const errorName = `${type}Mismatch`;
+      const otherErrors = value2Input.errors;
+      return value1Input.value !== value2Input.value
+        ? value2Input.setErrors({ [errorName]: true, ...otherErrors })
+        : value2Input.setErrors(otherErrors);
     };
   }
 }

--- a/src/app/modules/auth/pages/register/register.component.ts
+++ b/src/app/modules/auth/pages/register/register.component.ts
@@ -97,22 +97,6 @@ export class RegisterComponent implements OnInit {
     );
   }
 
-  checkPasswords(control: FormGroup) {
-    const password = control.get("password");
-    const confirmPassword = control.get("confirmPassword");
-
-    const passwordsEqual = password.value === confirmPassword.value;
-
-    if (passwordsEqual) {
-      confirmPassword.setErrors(null);
-    } else {
-      confirmPassword.setErrors({
-        passwordMismatch: true,
-        ...confirmPassword.errors
-      });
-    }
-  }
-
   submit() {
     this.isSubmitted = true;
     this.registerForm.markAllAsTouched();

--- a/src/app/modules/auth/pages/register/register.component.ts
+++ b/src/app/modules/auth/pages/register/register.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { Router } from "@angular/router";
 import { IInputs } from "@app/shared/interfaces";
 import { fadeIn, fadeOut } from "@app/shared/animations";
+import { FormsService } from "@app/core/services/forms.service";
 
 @Component({
   selector: "app-register",
@@ -48,7 +49,11 @@ export class RegisterComponent implements OnInit {
       type: "password"
     }
   };
-  constructor(private formBuilder: FormBuilder, private router: Router) {}
+  constructor(
+    private formBuilder: FormBuilder,
+    private router: Router,
+    private formsService: FormsService
+  ) {}
 
   ngOnInit() {
     this.initForm();
@@ -80,7 +85,15 @@ export class RegisterComponent implements OnInit {
           ])
         ]
       },
-      { validator: this.checkPasswords }
+      {
+        validators: [
+          this.formsService.checkIfValuesMatching(
+            "password",
+            "confirmPassword",
+            "password"
+          )
+        ]
+      }
     );
   }
 

--- a/src/app/modules/settings/pages/change-email/change-email.component.ts
+++ b/src/app/modules/settings/pages/change-email/change-email.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { Router } from "@angular/router";
 import { IInputs } from "@app/shared/interfaces";
 import { fadeIn, fadeOut } from "@app/shared/animations";
+import { FormsService } from "@app/core/services/forms.service";
 
 @Component({
   selector: "app-change-email",
@@ -31,20 +32,38 @@ export class ChangeEmailComponent implements OnInit {
       type: "email"
     }
   };
-  constructor(private formBuilder: FormBuilder, private router: Router) {}
+  constructor(
+    private formBuilder: FormBuilder,
+    private router: Router,
+    private formsService: FormsService
+  ) {}
 
   ngOnInit() {
     this.initForm();
   }
 
   initForm() {
-    this.changeEmailForm = this.formBuilder.group({
-      email: ["", Validators.compose([Validators.required, Validators.email])],
-      confirmEmail: [
-        "",
-        Validators.compose([Validators.required, Validators.email])
-      ]
-    });
+    this.changeEmailForm = this.formBuilder.group(
+      {
+        email: [
+          "",
+          Validators.compose([Validators.required, Validators.email])
+        ],
+        confirmEmail: [
+          "",
+          Validators.compose([Validators.required, Validators.email])
+        ]
+      },
+      {
+        validators: [
+          this.formsService.checkIfValuesMatching(
+            "email",
+            "confirmEmail",
+            "email"
+          )
+        ]
+      }
+    );
   }
 
   submit() {

--- a/src/app/modules/settings/pages/change-password/change-password.component.ts
+++ b/src/app/modules/settings/pages/change-password/change-password.component.ts
@@ -88,22 +88,6 @@ export class ChangePasswordComponent implements OnInit {
     );
   }
 
-  checkPasswords(control: FormGroup) {
-    const password = control.get("password");
-    const confirmPassword = control.get("confirmPassword");
-
-    const passwordsEqual = password.value === confirmPassword.value;
-
-    if (passwordsEqual) {
-      confirmPassword.setErrors(confirmPassword.errors);
-    } else {
-      confirmPassword.setErrors({
-        passwordMismatch: true,
-        ...confirmPassword.errors
-      });
-    }
-  }
-
   submit() {
     this.isSubmitted = true;
     this.changePasswordForm.markAllAsTouched();

--- a/src/app/modules/settings/pages/change-password/change-password.component.ts
+++ b/src/app/modules/settings/pages/change-password/change-password.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { Router } from "@angular/router";
 import { IInputs } from "@app/shared/interfaces";
 import { fadeIn, fadeOut } from "@app/shared/animations";
+import { FormsService } from "@app/core/services/forms.service";
 
 @Component({
   selector: "app-change-password",
@@ -37,7 +38,11 @@ export class ChangePasswordComponent implements OnInit {
       type: "password"
     }
   };
-  constructor(private formBuilder: FormBuilder, private router: Router) {}
+  constructor(
+    private formBuilder: FormBuilder,
+    private router: Router,
+    private formsService: FormsService
+  ) {}
 
   ngOnInit() {
     this.initForm();
@@ -71,7 +76,15 @@ export class ChangePasswordComponent implements OnInit {
           ])
         ]
       },
-      { validator: this.checkPasswords }
+      {
+        validators: [
+          this.formsService.checkIfValuesMatching(
+            "password",
+            "confirmPassword",
+            "password"
+          )
+        ]
+      }
     );
   }
 

--- a/src/app/shared/forms/input/input.component.html
+++ b/src/app/shared/forms/input/input.component.html
@@ -14,9 +14,10 @@
     <mat-error *ngIf="formSubmitted && formGroup.controls[formControlNameValue].errors && formGroup.controls[formControlNameValue].errors.max">Wartość za duża</mat-error>
     <mat-error *ngIf="formSubmitted && formGroup.controls[formControlNameValue].errors && formGroup.controls[formControlNameValue].errors.minlength">Wartość za krótka</mat-error>
     <mat-error *ngIf="formSubmitted && formGroup.controls[formControlNameValue].errors && formGroup.controls[formControlNameValue].errors.maxlength">Wartość za długa</mat-error>
-    <mat-error *ngIf="formSubmitted && formGroup.controls[formControlNameValue].errors && formGroup.controls[formControlNameValue].errors.notEquivalent">Wartości nie pasują do siebie</mat-error>
+    <mat-error *ngIf="formSubmitted && formGroup.controls[formControlNameValue].errors && formGroup.controls[formControlNameValue].errors.valueMismatch">Wartości nie pasują do siebie</mat-error>
     <mat-error *ngIf="formSubmitted && formGroup.controls[formControlNameValue].errors && formGroup.controls[formControlNameValue].errors.alreadyAdded">Konto z adresem email już istnieje</mat-error>
     <mat-error *ngIf="formSubmitted && formGroup.controls[formControlNameValue].errors && formGroup.controls[formControlNameValue].errors.passwordMismatch">Hasła nie pasują do siebie</mat-error>
+    <mat-error *ngIf="formSubmitted && formGroup.controls[formControlNameValue].errors && formGroup.controls[formControlNameValue].errors.emailMismatch">Adresy e-mail nie pasują do siebie</mat-error>
     <mat-error *ngIf="formSubmitted && formGroup.controls[formControlNameValue].errors && formGroup.controls[formControlNameValue].errors.usernameTaken">Ta nazwa użytkownika jest już zajęta</mat-error>
   </mat-form-field>
   <!-- {{formSubmitted}}  -->


### PR DESCRIPTION
Zmiany:
- dodano komunikat błędu dla niezgodnych adresów email (np. formularz zmiany adresu email)
- funkcja `checkIfValuesMatching()` w serwisie `forms.service.ts` przyjmuje dodatkowy parametr `type`, który określa typ sprawdzanego pola, a raczej przedrostek dla kodu błędu wyświetlanego przez komponent  input'a. Dzięki temu można wyświetlać odpowiednie komunikaty dla haseł i emaili. Domyślnie parametr przyjmuje wartość "value", a więc wyświetli błąd `valueMismatch` (wcześniej nazywany `notEquivalent`)
- usunięto wcześniejsze komparatory haseł
- formatowanie kodu (Prettier)